### PR TITLE
Use BorrowedFds when sending messages

### DIFF
--- a/crates/core/src/payload.rs
+++ b/crates/core/src/payload.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::VecDeque,
-    os::fd::{AsRawFd as _, BorrowedFd, RawFd},
+    os::fd::{AsFd, AsRawFd as _, RawFd},
 };
 
 use bytes::{BufMut, Bytes, BytesMut};
@@ -107,8 +107,8 @@ impl PayloadBuilder {
         self
     }
 
-    pub fn put_fd(mut self, fd: BorrowedFd) -> Self {
-        self.fds.push_back(fd.as_raw_fd());
+    pub fn put_fd<Fd: AsFd>(mut self, fd: Fd) -> Self {
+        self.fds.push_back(fd.as_fd().as_raw_fd());
 
         self
     }

--- a/crates/core/src/payload.rs
+++ b/crates/core/src/payload.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::VecDeque,
-    os::fd::{IntoRawFd, OwnedFd, RawFd},
+    os::fd::{AsRawFd as _, BorrowedFd, RawFd},
 };
 
 use bytes::{BufMut, Bytes, BytesMut};
@@ -107,8 +107,8 @@ impl PayloadBuilder {
         self
     }
 
-    pub fn put_fd<Fd: Into<OwnedFd>>(mut self, fd: Fd) -> Self {
-        self.fds.push_back(fd.into().into_raw_fd());
+    pub fn put_fd(mut self, fd: BorrowedFd) -> Self {
+        self.fds.push_back(fd.as_raw_fd());
 
         self
     }

--- a/crates/gen/src/lib.rs
+++ b/crates/gen/src/lib.rs
@@ -153,7 +153,7 @@ impl<'a> ProtocolGenerator<'a> {
             let mut args = Vec::new();
 
             for arg in &message.args {
-                let mut ty = self.arg_to_rust_type_token(arg)?;
+                let mut ty = self.arg_to_rust_type_token(arg, generate_body)?;
 
                 if arg.allow_null {
                     ty = quote! {Option<#ty>};
@@ -350,7 +350,11 @@ impl<'a> ProtocolGenerator<'a> {
         dispatchers
     }
 
-    pub fn arg_to_rust_type_token(&self, arg: &Arg) -> Result<TokenStream, Error> {
+    pub fn arg_to_rust_type_token(
+        &self,
+        arg: &Arg,
+        generate_body: bool,
+    ) -> Result<TokenStream, Error> {
         if let Some(e) = &arg.r#enum {
             if let Some((interface, name)) = e.split_once('.') {
                 for (module, protocols) in self.protocols {
@@ -374,6 +378,6 @@ impl<'a> ProtocolGenerator<'a> {
             return Ok(make_ident(e.to_upper_camel_case()).to_token_stream());
         }
 
-        Ok(arg.to_underlying_type_token())
+        Ok(arg.to_underlying_type_token(generate_body))
     }
 }

--- a/crates/gen/src/parser.rs
+++ b/crates/gen/src/parser.rs
@@ -144,7 +144,7 @@ pub struct Entry {
 }
 
 impl Arg {
-    pub fn to_underlying_type_token(&self) -> TokenStream {
+    pub fn to_underlying_type_token(&self, generate_body: bool) -> TokenStream {
         match self.ty {
             ArgType::Int => quote! { i32 },
             ArgType::Uint => quote! { u32 },
@@ -159,7 +159,13 @@ impl Arg {
                 }
             }
             ArgType::Array => quote! { Vec<u8> },
-            ArgType::Fd => quote! { std::os::fd::OwnedFd },
+            ArgType::Fd => {
+                if generate_body {
+                    quote! { std::os::fd::BorrowedFd }
+                } else {
+                    quote! { std::os::fd::OwnedFd }
+                }
+            }
         }
     }
 

--- a/crates/protocols/src/client/core.rs
+++ b/crates/protocols/src/client/core.rs
@@ -882,7 +882,7 @@ pub mod wayland {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
                 size: i32,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
@@ -1124,7 +1124,7 @@ pub mod wayland {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 mime_type: String,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {

--- a/crates/protocols/src/client/mesa.rs
+++ b/crates/protocols/src/client/mesa.rs
@@ -330,7 +330,7 @@ pub mod drm {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 id: waynest::ObjectId,
-                name: std::os::fd::OwnedFd,
+                name: std::os::fd::BorrowedFd,
                 width: i32,
                 height: i32,
                 format: u32,

--- a/crates/protocols/src/client/plasma.rs
+++ b/crates/protocols/src/client/plasma.rs
@@ -6385,7 +6385,7 @@ pub mod plasma_window_management {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {

--- a/crates/protocols/src/client/stable.rs
+++ b/crates/protocols/src/client/stable.rs
@@ -367,7 +367,7 @@ pub mod linux_dmabuf_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
                 plane_idx: u32,
                 offset: u32,
                 stride: u32,

--- a/crates/protocols/src/client/staging.rs
+++ b/crates/protocols/src/client/staging.rs
@@ -1380,7 +1380,7 @@ pub mod color_management_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                icc_profile: std::os::fd::OwnedFd,
+                icc_profile: std::os::fd::BorrowedFd,
                 offset: u32,
                 length: u32,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
@@ -4786,7 +4786,7 @@ pub mod ext_data_control_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 mime_type: String,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -7968,7 +7968,7 @@ pub mod linux_drm_syncobj_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -8454,8 +8454,8 @@ pub mod security_context_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 id: waynest::ObjectId,
-                listen_fd: std::os::fd::OwnedFd,
-                close_fd: std::os::fd::OwnedFd,
+                listen_fd: std::os::fd::BorrowedFd,
+                close_fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {

--- a/crates/protocols/src/client/unstable.rs
+++ b/crates/protocols/src/client/unstable.rs
@@ -1998,7 +1998,7 @@ pub mod linux_dmabuf_unstable_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
                 plane_idx: u32,
                 offset: u32,
                 stride: u32,
@@ -2689,7 +2689,7 @@ pub mod zwp_linux_explicit_synchronization_unstable_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -3960,7 +3960,7 @@ pub mod wp_primary_selection_unstable_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 mime_type: String,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {

--- a/crates/protocols/src/client/weston.rs
+++ b/crates/protocols/src/client/weston.rs
@@ -1032,7 +1032,7 @@ pub mod color_management_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                icc_profile: std::os::fd::OwnedFd,
+                icc_profile: std::os::fd::BorrowedFd,
                 offset: u32,
                 length: u32,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
@@ -2832,7 +2832,7 @@ pub mod weston_debug {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 name: String,
-                streamfd: std::os::fd::OwnedFd,
+                streamfd: std::os::fd::BorrowedFd,
                 stream: waynest::ObjectId,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {

--- a/crates/protocols/src/client/wlr.rs
+++ b/crates/protocols/src/client/wlr.rs
@@ -428,7 +428,7 @@ pub mod wlr_data_control_unstable_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 mime_type: String,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -1358,7 +1358,7 @@ pub mod wlr_gamma_control_unstable_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {

--- a/crates/protocols/src/server/core.rs
+++ b/crates/protocols/src/server/core.rs
@@ -1604,7 +1604,7 @@ pub mod wayland {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 mime_type: String,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -4713,7 +4713,7 @@ pub mod wayland {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 format: KeymapFormat,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
                 size: u32,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {

--- a/crates/protocols/src/server/cosmic.rs
+++ b/crates/protocols/src/server/cosmic.rs
@@ -388,7 +388,7 @@ pub mod cosmic_atspi_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {

--- a/crates/protocols/src/server/plasma.rs
+++ b/crates/protocols/src/server/plasma.rs
@@ -8608,7 +8608,7 @@ pub mod remote_access {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
                 width: u32,
                 height: u32,
                 stride: u32,

--- a/crates/protocols/src/server/stable.rs
+++ b/crates/protocols/src/server/stable.rs
@@ -745,7 +745,7 @@ pub mod linux_dmabuf_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
                 size: u32,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {

--- a/crates/protocols/src/server/staging.rs
+++ b/crates/protocols/src/server/staging.rs
@@ -2343,7 +2343,7 @@ pub mod color_management_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                icc: std::os::fd::OwnedFd,
+                icc: std::os::fd::BorrowedFd,
                 icc_size: u32,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
@@ -4129,7 +4129,7 @@ pub mod drm_lease_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -4603,7 +4603,7 @@ pub mod drm_lease_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                leased_fd: std::os::fd::OwnedFd,
+                leased_fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -5338,7 +5338,7 @@ pub mod ext_data_control_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 mime_type: String,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {

--- a/crates/protocols/src/server/unstable.rs
+++ b/crates/protocols/src/server/unstable.rs
@@ -2628,7 +2628,7 @@ pub mod linux_dmabuf_unstable_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
                 size: u32,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
@@ -3231,7 +3231,7 @@ pub mod zwp_linux_explicit_synchronization_unstable_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                fence: std::os::fd::OwnedFd,
+                fence: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -4854,7 +4854,7 @@ pub mod wp_primary_selection_unstable_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 mime_type: String,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {

--- a/crates/protocols/src/server/weston.rs
+++ b/crates/protocols/src/server/weston.rs
@@ -1951,7 +1951,7 @@ pub mod color_management_v1 {
                 &self,
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
-                icc: std::os::fd::OwnedFd,
+                icc: std::os::fd::BorrowedFd,
                 icc_size: u32,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {

--- a/crates/protocols/src/server/wlr.rs
+++ b/crates/protocols/src/server/wlr.rs
@@ -407,7 +407,7 @@ pub mod wlr_data_control_unstable_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 mime_type: String,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
             ) -> impl Future<Output = Result<(), <Self::Connection as waynest::Connection>::Error>> + Send
             {
                 async move {
@@ -835,7 +835,7 @@ pub mod wlr_export_dmabuf_unstable_v1 {
                 connection: &mut Self::Connection,
                 sender_id: waynest::ObjectId,
                 index: u32,
-                fd: std::os::fd::OwnedFd,
+                fd: std::os::fd::BorrowedFd,
                 size: u32,
                 offset: u32,
                 stride: u32,


### PR DESCRIPTION
this is done since the fds aren't closed when sending a message, causing OwnedFds to be leaked